### PR TITLE
chore: code cleanup for php 8.1

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 5
     paths:
         - src
         - tests

--- a/src/Annotation/Index.php
+++ b/src/Annotation/Index.php
@@ -37,8 +37,7 @@ class Index
     public function __construct(
         public string $formatter = DefaultFormatter::class,
         public array $groups = ['default'],
-        public array $formatterOptions = [
-        ]
+        public array $formatterOptions = []
     ) {
     }
 

--- a/src/Command/PopulateCommand.php
+++ b/src/Command/PopulateCommand.php
@@ -44,7 +44,7 @@ class PopulateCommand extends BaseCommand implements PopulateOutputInterface
     public function __construct(
         protected PopulatorInterface $populator
     ) {
-        parent::__construct(null);
+        parent::__construct();
     }
 
     public function progressStart(int $max): void

--- a/src/Command/SearchCommand.php
+++ b/src/Command/SearchCommand.php
@@ -34,7 +34,6 @@ use araise\CoreBundle\Manager\FormatterManager;
 use araise\SearchBundle\Entity\Index;
 use araise\SearchBundle\Manager\IndexManager;
 use araise\SearchBundle\Repository\IndexRepository;
-use Doctrine\ORM\EntityManager;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -43,33 +42,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SearchCommand extends BaseCommand
 {
-    /**
-     * @var EntityManager
-     */
-    protected $em;
-
-    /**
-     * @var ManagerRegistry
-     */
-    protected $doctrine;
-
-    /**
-     * @var IndexManager
-     */
-    protected $indexManager;
-
-    /**
-     * @var FormatterManager
-     */
-    protected $formatterManager;
-
-    public function __construct(ManagerRegistry $doctrine, IndexManager $indexManager, FormatterManager $formatterManager)
-    {
-        parent::__construct(null);
-
-        $this->doctrine = $doctrine;
-        $this->indexManager = $indexManager;
-        $this->formatterManager = $formatterManager;
+    public function __construct(
+        protected ManagerRegistry $doctrine,
+        protected IndexManager $indexManager,
+        protected FormatterManager $formatterManager
+    ) {
+        parent::__construct();
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,6 +18,11 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('araise_search');
         $rootNode = $treeBuilder->getRootNode();
+
+        if (!method_exists($rootNode, 'children')) {
+            throw new \RuntimeException();
+        }
+
         $rootNode
             ->children()
             ->arrayNode('chains')

--- a/src/DependencyInjection/araiseSearchExtension.php
+++ b/src/DependencyInjection/araiseSearchExtension.php
@@ -7,7 +7,6 @@ namespace araise\SearchBundle\DependencyInjection;
 use araise\SearchBundle\Manager\IndexManager;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -27,7 +26,6 @@ class araiseSearchExtension extends Extension implements PrependExtensionInterfa
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');
 
-        /** @var Definition $indexManager */
         $indexManager = $container->getDefinition(IndexManager::class);
         $indexManager->addMethodCall('setConfig', [$config]);
 

--- a/src/Entity/Index.php
+++ b/src/Entity/Index.php
@@ -29,141 +29,87 @@ declare(strict_types=1);
 
 namespace araise\SearchBundle\Entity;
 
+use araise\SearchBundle\Repository\IndexRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Table(name: 'araise_search_index')]
 #[ORM\Index(columns: ['content'], flags: ['fulltext'])]
 #[ORM\Index(columns: ['model'])]
 #[ORM\UniqueConstraint(name: 'search_index', columns: ['foreign_id', 'model', 'grp'])]
-#[ORM\Entity(repositoryClass: 'araise\SearchBundle\Repository\IndexRepository')]
+#[ORM\Entity(repositoryClass: IndexRepository::class)]
 class Index
 {
-    /**
-     * @var int
-     */
     #[ORM\Column(name: 'id', type: 'bigint', nullable: false)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    protected int $id;
 
-    /**
-     * @var int
-     */
     #[ORM\Column(name: 'foreign_id', type: 'integer', nullable: false)]
-    protected $foreignId;
+    protected int $foreignId;
 
-    /**
-     * @var string
-     */
     #[ORM\Column(name: 'model', type: 'string', length: 150, nullable: false)]
-    protected $model;
+    protected string $model;
 
-    /**
-     * @var string
-     */
     #[ORM\Column(name: 'grp', type: 'string', length: 90, nullable: false)]
-    protected $group;
+    protected string $group;
 
-    /**
-     * @var string
-     */
     #[ORM\Column(name: 'content', type: 'text', nullable: false)]
-    protected $content;
+    protected string $content;
 
-    /**
-     * @return int
-     */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     *
-     * @return self
-     */
-    public function setId($id)
+    public function setId(int $id): self
     {
         $this->id = $id;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getForeignId()
+    public function getForeignId(): int
     {
         return $this->foreignId;
     }
 
-    /**
-     * @param int $foreignId
-     *
-     * @return self
-     */
-    public function setForeignId($foreignId)
+    public function setForeignId(int $foreignId): self
     {
         $this->foreignId = $foreignId;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getModel()
+    public function getModel(): string
     {
         return $this->model;
     }
 
-    /**
-     * @param string $model
-     *
-     * @return self
-     */
-    public function setModel($model)
+    public function setModel(string $model): self
     {
         $this->model = $model;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getGroup()
+    public function getGroup(): string
     {
         return $this->group;
     }
 
-    /**
-     * @param string $group
-     *
-     * @return self
-     */
-    public function setGroup($group)
+    public function setGroup(string $group): self
     {
         $this->group = $group;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getContent()
+    public function getContent(): string
     {
         return $this->content;
     }
 
-    /**
-     * @param string $content
-     *
-     * @return self
-     */
-    public function setContent($content)
+    public function setContent(string $content): self
     {
         $this->content = $content;
 

--- a/src/Entity/PreSearchInterface.php
+++ b/src/Entity/PreSearchInterface.php
@@ -8,5 +8,5 @@ use Doctrine\ORM\QueryBuilder;
 
 interface PreSearchInterface
 {
-    public function preSearch(QueryBuilder $qb, string $query, ? string $entity, ? string $field): void;
+    public function preSearch(QueryBuilder $qb, string $query, ?string $entity, ?string $field): void;
 }

--- a/src/Entity/PreSearchInterface.php
+++ b/src/Entity/PreSearchInterface.php
@@ -8,5 +8,5 @@ use Doctrine\ORM\QueryBuilder;
 
 interface PreSearchInterface
 {
-    public function preSearch(QueryBuilder &$qb, string $query, ? string $entity, ? string $field): void;
+    public function preSearch(QueryBuilder $qb, string $query, ? string $entity, ? string $field): void;
 }

--- a/src/EventListener/IndexListener.php
+++ b/src/EventListener/IndexListener.php
@@ -33,68 +33,21 @@ use araise\CoreBundle\Manager\FormatterManager;
 use araise\SearchBundle\Manager\IndexManager;
 use araise\SearchBundle\Populator\PopulatorInterface;
 use Doctrine\Common\EventSubscriber;
-use Doctrine\DBAL\Statement;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 
 class IndexListener implements EventSubscriber
 {
-    /**
-     * @var IndexManager
-     */
-    protected $indexManager;
-
-    /**
-     * @var Statement
-     */
-    protected $indexInsertStmt;
-
-    /**
-     * @var Statement
-     */
-    protected $indexUpdateStmt;
-
-    /**
-     * @var FormatterManager
-     */
-    protected $formatterManager;
-
-    /**
-     * Prevent infinite recursion.
-     *
-     * @var array
-     */
-    protected static $indexVisited = [];
-
-    /**
-     * Prevent infinite recursion.
-     *
-     * @var array
-     */
-    protected static $removeVisited = [];
-
-    private EntityManagerInterface $entityManager;
-
-    private PopulatorInterface $populator;
-
     public function __construct(
-        IndexManager $indexManager,
-        FormatterManager $formatterManager,
-        EntityManagerInterface $entityManager,
-        PopulatorInterface $populator
+        protected IndexManager $indexManager,
+        protected FormatterManager $formatterManager,
+        private PopulatorInterface $populator
     ) {
-        $this->indexManager = $indexManager;
-        $this->formatterManager = $formatterManager;
-        $this->entityManager = $entityManager;
-        $this->populator = $populator;
     }
 
     /**
      * Returns an array of events this subscriber wants to listen to.
-     *
-     * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             'postPersist',
@@ -103,17 +56,17 @@ class IndexListener implements EventSubscriber
         ];
     }
 
-    public function postPersist(LifecycleEventArgs $args)
+    public function postPersist(LifecycleEventArgs $args): void
     {
         $this->populator->index($args->getObject());
     }
 
-    public function postUpdate(LifecycleEventArgs $args)
+    public function postUpdate(LifecycleEventArgs $args): void
     {
         $this->populator->index($args->getObject());
     }
 
-    public function preRemove(LifecycleEventArgs $args)
+    public function preRemove(LifecycleEventArgs $args): void
     {
         $this->populator->remove($args->getObject());
     }

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -10,10 +10,6 @@ abstract class AbstractFilter implements FilterInterface
 {
     protected array $options = [];
 
-    public function __construct()
-    {
-    }
-
     public function setOptions(array $options): void
     {
         $resolver = new OptionsResolver();

--- a/src/Manager/FilterManager.php
+++ b/src/Manager/FilterManager.php
@@ -20,7 +20,7 @@ class FilterManager
         $this->filterList[$chain][$filter->getPriority()][] = $filter;
     }
 
-    public function process(string $data, string $chain)
+    public function process(string $data, string $chain): string
     {
         $tokens = $this->getTokens($data, $chain);
 
@@ -39,12 +39,12 @@ class FilterManager
         return implode(' ', $tokens);
     }
 
-    public function addTokenizer(TokenizerInterface $tokenizer, string $chain)
+    public function addTokenizer(TokenizerInterface $tokenizer, string $chain): void
     {
         $this->tockenizers[$chain][$tokenizer->getPriority()][] = $tokenizer;
     }
 
-    private function getTokens(string $value, string $chain)
+    private function getTokens(string $value, string $chain): array
     {
         $tokens = [];
         if (! isset($this->tockenizers[$chain])) {

--- a/src/Manager/IndexManager.php
+++ b/src/Manager/IndexManager.php
@@ -32,6 +32,7 @@ namespace araise\SearchBundle\Manager;
 use araise\SearchBundle\Annotation\Index as AttributeIndex;
 use araise\SearchBundle\Entity\Index as EntityIndex;
 use araise\SearchBundle\Exception\MethodNotFoundException;
+use araise\SearchBundle\Repository\IndexRepositoryInterface;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\DBAL;
 use Doctrine\ORM\EntityManager;
@@ -173,6 +174,13 @@ class IndexManager
         $this->config = $config;
 
         return $this;
+    }
+
+    public function getRepository(): IndexRepositoryInterface
+    {
+        /** @var IndexRepositoryInterface $repository */
+        $repository = $this->doctrine->getRepository(EntityIndex::class);
+        return $repository;
     }
 
     protected function getEntityManager(): EntityManager

--- a/src/Manager/SearchManager.php
+++ b/src/Manager/SearchManager.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
 class SearchManager
 {
     public function __construct(
-        protected IndexRepository $indexRepository,
+        private readonly IndexRepository $indexRepository,
         private readonly EntityManagerInterface $entityManager
     ) {
     }

--- a/src/Model/ResultItem.php
+++ b/src/Model/ResultItem.php
@@ -7,9 +7,9 @@ namespace araise\SearchBundle\Model;
 class ResultItem
 {
     public function __construct(
-        private int $id,
-        private string $class,
-        private float $score,
+        private readonly int $id,
+        private readonly string $class,
+        private readonly float $score,
         private $entity
     ) {
     }

--- a/src/Populator/NullPopulateOutput.php
+++ b/src/Populator/NullPopulateOutput.php
@@ -6,7 +6,7 @@ namespace araise\SearchBundle\Populator;
 
 class NullPopulateOutput implements PopulateOutputInterface
 {
-    public function log(string $string)
+    public function log(string $string): void
     {
     }
 

--- a/src/Populator/OneFieldPopulator.php
+++ b/src/Populator/OneFieldPopulator.php
@@ -51,7 +51,7 @@ class OneFieldPopulator extends AbstractPopulator
             $groupedContent = $this->collectEntityIndexData($entityName, $entity);
 
             foreach ($groupedContent as $group => $content) {
-                $entry = $this->entityManager->getRepository(Index::class)->findExisting($class, $group, $entity->{$idMethod}());
+                $entry = $this->indexManager->getRepository()->findExisting($class, $group, $entity->{$idMethod}());
                 if (! $entry) {
                     $insertData = [];
                     $insertSqlParts = [];

--- a/src/Populator/OneFieldPopulator.php
+++ b/src/Populator/OneFieldPopulator.php
@@ -7,12 +7,21 @@ namespace araise\SearchBundle\Populator;
 use araise\SearchBundle\Entity\Index;
 use araise\SearchBundle\Exception\MethodNotFoundException;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\DBAL;
+use Doctrine\DBAL\Exception;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 
 class OneFieldPopulator extends AbstractPopulator
 {
-    public function index(object $entity)
+    /**
+     * @throws MappingException
+     * @throws MethodNotFoundException
+     * @throws \ReflectionException
+     * @throws Exception
+     */
+    public function index(object $entity): void
     {
         if ($this->disableEntityListener) {
             return;
@@ -39,7 +48,6 @@ class OneFieldPopulator extends AbstractPopulator
 
             $idMethod = $this->indexManager->getIdMethod($class);
 
-            /** @var \araise\SearchBundle\Annotation\Index $index */
             $groupedContent = $this->collectEntityIndexData($entityName, $entity);
 
             foreach ($groupedContent as $group => $content) {
@@ -67,8 +75,9 @@ class OneFieldPopulator extends AbstractPopulator
      * @throws ORMException
      * @throws OptimisticLockException
      * @throws MethodNotFoundException
+     * @throws \ReflectionException|DBAL\Exception
      */
-    protected function indexEntity($entityName)
+    protected function indexEntity(string $entityName): void
     {
         $workingValues = $this->getIndexEntityWorkingValues($entityName);
         if ($workingValues === false) {
@@ -119,12 +128,16 @@ class OneFieldPopulator extends AbstractPopulator
     /**
      * Clean up garbage.
      */
-    protected function gc()
+    protected function gc(): void
     {
         $this->entityManager->clear();
         gc_collect_cycles();
     }
 
+    /**
+     * @throws \ReflectionException
+     * @throws MethodNotFoundException
+     */
     protected function collectEntityIndexData($entityName, $entity): array
     {
         $indexes = $this->indexManager->getIndexesOfEntity($entityName);

--- a/src/Populator/OneFieldPopulator.php
+++ b/src/Populator/OneFieldPopulator.php
@@ -51,7 +51,7 @@ class OneFieldPopulator extends AbstractPopulator
             $groupedContent = $this->collectEntityIndexData($entityName, $entity);
 
             foreach ($groupedContent as $group => $content) {
-                $entry = $this->indexManager->getRepository()->findExisting($class, $group, $entity->{$idMethod}());
+                $entry = $this->indexManager->getIndexRepository()->findExisting($class, $group, $entity->{$idMethod}());
                 if (! $entry) {
                     $insertData = [];
                     $insertSqlParts = [];

--- a/src/Populator/PopulatorInterface.php
+++ b/src/Populator/PopulatorInterface.php
@@ -6,6 +6,10 @@ namespace araise\SearchBundle\Populator;
 
 interface PopulatorInterface
 {
+    public function index(object $entity);
+
+    public function remove(object $entity);
+
     public function populate(?PopulateOutputInterface $output, ?string $entityClass): void;
 
     public function disableEntityListener(bool $disable);

--- a/src/Populator/StandardPopulator.php
+++ b/src/Populator/StandardPopulator.php
@@ -55,7 +55,7 @@ class StandardPopulator extends AbstractPopulator
                 }
                 $content = $formatter->getString($entity->{$fieldMethod}());
                 if (! empty($content)) {
-                    $entry = $this->indexManager->getRepository()->findExisting($class, $field, $entity->{$idMethod}());
+                    $entry = $this->indexManager->getIndexRepository()->findExisting($class, $field, $entity->{$idMethod}());
                     if (! $entry) {
                         $insertData = [];
                         $insertSqlParts = [];

--- a/src/Populator/StandardPopulator.php
+++ b/src/Populator/StandardPopulator.php
@@ -55,7 +55,7 @@ class StandardPopulator extends AbstractPopulator
                 }
                 $content = $formatter->getString($entity->{$fieldMethod}());
                 if (! empty($content)) {
-                    $entry = $this->entityManager->getRepository(Index::class)->findExisting($class, $field, $entity->{$idMethod}());
+                    $entry = $this->indexManager->getRepository()->findExisting($class, $field, $entity->{$idMethod}());
                     if (! $entry) {
                         $insertData = [];
                         $insertSqlParts = [];

--- a/src/Populator/StandardPopulator.php
+++ b/src/Populator/StandardPopulator.php
@@ -7,12 +7,18 @@ namespace araise\SearchBundle\Populator;
 use araise\SearchBundle\Entity\Index;
 use araise\SearchBundle\Exception\MethodNotFoundException;
 use Doctrine\Common\Util\ClassUtils;
-use Doctrine\ORM\OptimisticLockException;
-use Doctrine\ORM\ORMException;
+use Doctrine\DBAL;
+use Doctrine\ORM\Mapping\MappingException;
 
 class StandardPopulator extends AbstractPopulator
 {
-    public function index(object $entity)
+    /**
+     * @throws MethodNotFoundException
+     * @throws MappingException
+     * @throws \ReflectionException
+     * @throws DBAL\Exception
+     */
+    public function index(object $entity): void
     {
         if ($this->disableEntityListener) {
             return;
@@ -71,11 +77,12 @@ class StandardPopulator extends AbstractPopulator
     /**
      * Populate index of given entity.
      *
-     * @throws ORMException
-     * @throws OptimisticLockException
+     * @throws DBAL\Exception
+     * @throws MappingException
      * @throws MethodNotFoundException
+     * @throws \ReflectionException
      */
-    protected function indexEntity($entityName)
+    protected function indexEntity(string $entityName): void
     {
         [$entities, $idMethod, $indexes] = $this->getIndexEntityWorkingValues($entityName);
 
@@ -129,7 +136,7 @@ class StandardPopulator extends AbstractPopulator
     /**
      * Clean up garbage.
      */
-    protected function gc()
+    protected function gc(): void
     {
         $this->entityManager->clear();
         gc_collect_cycles();

--- a/src/Repository/IndexRepository.php
+++ b/src/Repository/IndexRepository.php
@@ -35,6 +35,7 @@ use araise\SearchBundle\Entity\PostSearchInterface;
 use araise\SearchBundle\Entity\PreSearchInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\Persistence\ManagerRegistry;
 
 class IndexRepository extends ServiceEntityRepository
@@ -46,6 +47,9 @@ class IndexRepository extends ServiceEntityRepository
         parent::__construct($registry, Index::class);
     }
 
+    /**
+     * @throws \ReflectionException
+     */
     public function search($query, $entity = null, $group = null): array
     {
         $query = $this->queryEscape($query);
@@ -85,7 +89,7 @@ class IndexRepository extends ServiceEntityRepository
             $reflection = new \ReflectionClass($entity);
             $annotationReader = new AnnotationReader();
 
-            /** @var Searchable $searchableAnnotations */
+            /** @var ?Searchable $searchableAnnotations */
             $searchableAnnotations = $annotationReader->getClassAnnotation($reflection, Searchable::class);
 
             if ($searchableAnnotations) {
@@ -164,6 +168,9 @@ class IndexRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
+    /**
+     * @throws NonUniqueResultException
+     */
     public function findExisting(string $entityFqcn, string $group, int $foreignId): ?Index
     {
         return $this->createQueryBuilder('i')

--- a/src/Repository/IndexRepository.php
+++ b/src/Repository/IndexRepository.php
@@ -38,7 +38,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\Persistence\ManagerRegistry;
 
-class IndexRepository extends ServiceEntityRepository
+class IndexRepository extends ServiceEntityRepository implements IndexRepositoryInterface
 {
     public function __construct(
         private bool $asteriskSearchEnabled,

--- a/src/Repository/IndexRepositoryInterface.php
+++ b/src/Repository/IndexRepositoryInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * Copyright (c) 2023, whatwedo GmbH
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace araise\SearchBundle\Repository;
+
+use araise\SearchBundle\Entity\Index;
+
+interface IndexRepositoryInterface
+{
+    public function search($query, $entity = null, $group = null): array;
+
+    public function searchEntities($query, array $entities = [], array $groups = []): array;
+
+    public function findExisting(string $entityFqcn, string $group, int $foreignId): ?Index;
+}

--- a/src/Traits/SearchTrait.php
+++ b/src/Traits/SearchTrait.php
@@ -6,6 +6,7 @@ namespace araise\SearchBundle\Traits;
 
 use araise\SearchBundle\Manager\SearchManager;
 use araise\SearchBundle\Model\ResultItem;
+use Doctrine\Common\Annotations\AnnotationException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -49,6 +50,10 @@ trait SearchTrait
         return '@araiseSearch/index.html.twig';
     }
 
+    /**
+     * @throws \ReflectionException
+     * @throws AnnotationException
+     */
     protected function getGlobalResults(Request $request, SearchManager $searchManager, $options = []): array
     {
         $resolver = new OptionsResolver();
@@ -83,7 +88,7 @@ trait SearchTrait
                     $definition = $definitionManager->getDefinitionByEntity($item->getEntity());
 
                     return $definition->getEntityTitle();
-                } catch (\InvalidArgumentException|RouteNotFoundException $e) {
+                } catch (\InvalidArgumentException|RouteNotFoundException) {
                     // not found
                 }
             }
@@ -93,6 +98,7 @@ trait SearchTrait
 
         $this->searchOptions = $resolver->resolve($options);
 
+        $stopWatch = null;
         if ($this->searchOptions[Search::OPT_STOP_WATCH]) {
             $stopWatch = new Stopwatch();
             $stopWatch->start('araiseSearch');
@@ -154,15 +160,13 @@ trait SearchTrait
             }
         };
 
-        $templateParams = [
+        return [
             'results' => $results,
             'pagination' => $pagination,
             'searchTerm' => $searchTerm,
             'duration' => $this->searchOptions[Search::OPT_STOP_WATCH] ? $stopWatch->start('araiseSearch')->getDuration() : 0,
             'searchHelper' => $searchHelper,
         ];
-
-        return $templateParams;
     }
 
     private function orderResults(array $results): array

--- a/tests/AbstractIndexTest.php
+++ b/tests/AbstractIndexTest.php
@@ -18,7 +18,7 @@ abstract class AbstractIndexTest extends KernelTestCase
     use Factories;
     use ResetDatabase;
 
-    protected function createEntities()
+    protected function createEntities(): void
     {
         /** @var EntityManagerInterface $em */
         $em = self::getContainer()->get(EntityManagerInterface::class);

--- a/tests/AbstractSearchTest.php
+++ b/tests/AbstractSearchTest.php
@@ -27,7 +27,7 @@ abstract class AbstractSearchTest extends KernelTestCase
 
     private CompanyRepository $companyRepository;
 
-    protected function createEntities()
+    protected function createEntities(): void
     {
         CompanyFactory::createOne([
             'name' => 'whatwedo GmbH',

--- a/tests/App/Entity/Company.php
+++ b/tests/App/Entity/Company.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace araise\SearchBundle\Tests\App\Entity;
 
 use araise\SearchBundle\Annotation\Index;
+use araise\SearchBundle\Tests\App\Formatter\DummyFormatter;
+use araise\SearchBundle\Tests\App\Repository\CompanyRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Table(name: 'company')]
-#[ORM\Entity(repositoryClass: 'araise\SearchBundle\Tests\App\Repository\CompanyRepository')]
+#[ORM\Entity(repositoryClass: CompanyRepository::class)]
 class Company
 {
     #[ORM\Column(type: 'integer')]
@@ -25,7 +27,7 @@ class Company
     #[Assert\NotNull]
     private ?string $name = null;
 
-    #[Index(formatter: 'araise\SearchBundle\Tests\App\Formatter\DummyFormatter')]
+    #[Index(formatter: DummyFormatter::class)]
     #[ORM\Column(type: 'string')]
     #[Assert\NotBlank]
     #[Assert\NotNull]
@@ -44,10 +46,10 @@ class Company
     private ?string $taxIdentificationNumber = null;
 
     /**
-     * @var Collection|array<Contact> One Member has Many Departments
+     * @var Collection<Contact> One Member has Many Departments
      */
-    #[ORM\OneToMany(targetEntity: 'Contact', mappedBy: 'company')]
-    private $contacts;
+    #[ORM\OneToMany(mappedBy: 'company', targetEntity: Contact::class)]
+    private Collection $contacts;
 
     public function __construct()
     {

--- a/tests/App/Entity/Contact.php
+++ b/tests/App/Entity/Contact.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace araise\SearchBundle\Tests\App\Entity;
 
 use araise\SearchBundle\Annotation\Index;
+use araise\SearchBundle\Tests\App\Repository\ContactRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Table(name: 'contact')]
-#[ORM\Entity(repositoryClass: 'araise\SearchBundle\Tests\App\Repository\ContactRepository')]
+#[ORM\Entity(repositoryClass: ContactRepository::class)]
 class Contact implements \Stringable
 {
     #[ORM\Column(type: 'integer')]
@@ -26,7 +27,7 @@ class Contact implements \Stringable
     /**
      * Many Groups have Many Members.
      */
-    #[ORM\ManyToOne(targetEntity: 'Company', inversedBy: 'contacts')]
+    #[ORM\ManyToOne(targetEntity: Company::class, inversedBy: 'contacts')]
     private Company $company;
 
     public function __construct(Company $company)

--- a/tests/App/Entity/Person.php
+++ b/tests/App/Entity/Person.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace araise\SearchBundle\Tests\App\Entity;
 
+use araise\SearchBundle\Tests\App\Repository\PersonRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Table(name: 'person')]
-#[ORM\Entity(repositoryClass: 'araise\SearchBundle\Tests\App\Repository\PersonRepository')]
+#[ORM\Entity(repositoryClass: PersonRepository::class)]
 class Person
 {
     #[ORM\Column(type: 'integer')]

--- a/tests/FilterConfigurationTest.php
+++ b/tests/FilterConfigurationTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class FilterConfigurationTest extends KernelTestCase
 {
-    public function testConfig()
+    public function testConfig(): void
     {
         $config = Yaml::parse(
             file_get_contents(__DIR__.'/resources/config/basic.yaml')
@@ -29,7 +29,7 @@ class FilterConfigurationTest extends KernelTestCase
         self::assertIsArray($processedConfiguration);
     }
 
-    public function testFilterManagerConfig()
+    public function testFilterManagerConfig(): void
     {
         /** @var FilterManager $filterManager */
         $filterManager = self::getContainer()->get(FilterManager::class);

--- a/tests/FilterManagerTest.php
+++ b/tests/FilterManagerTest.php
@@ -16,7 +16,7 @@ class FilterManagerTest extends KernelTestCase
     use Factories;
     use ResetDatabase;
 
-    public function testFilter()
+    public function testFilter(): void
     {
         /** @var FilterManager $filterManager */
         $filterManager = self::getContainer()->get(FilterManager::class);
@@ -32,7 +32,7 @@ class FilterManagerTest extends KernelTestCase
         );
     }
 
-    public function testStandardTokenizer()
+    public function testStandardTokenizer(): void
     {
         /** @var FilterManager $filterManager */
         $filterManager = self::getContainer()->get(FilterManager::class);
@@ -47,7 +47,7 @@ class FilterManagerTest extends KernelTestCase
         );
     }
 
-    public function testNoChainDefined()
+    public function testNoChainDefined(): void
     {
         /** @var FilterManager $filterManager */
         $filterManager = self::getContainer()->get(FilterManager::class);

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class FilterTest extends TestCase
 {
-    public function testLowerCaseFilter()
+    public function testLowerCaseFilter(): void
     {
         $filter = new LowerCaseFilter();
 
@@ -23,7 +23,7 @@ class FilterTest extends TestCase
         ]));
     }
 
-    public function testRemoveFilter()
+    public function testRemoveFilter(): void
     {
         $filter = new RemoveFilter(['data1']);
 

--- a/tests/IndexListenerTest.php
+++ b/tests/IndexListenerTest.php
@@ -13,13 +13,12 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class IndexListenerTest extends AbstractIndexTest
 {
-    public function testEntityCreation()
+    public function testEntityCreation(): void
     {
         /** @var EntityManagerInterface $em */
         $em = self::getContainer()->get(EntityManagerInterface::class);
         self::assertSame(0, $em->getRepository(Index::class)->count([]));
 
-        /** @var Contact $contact */
         ContactFactory::createOne([
             'name' => 'Maurizio Monticelli',
             'company' => CompanyFactory::createOne([
@@ -31,7 +30,7 @@ class IndexListenerTest extends AbstractIndexTest
         ])->object();
 
         $indexResults = $em->getRepository(Index::class)->findAll();
-        self::assertSame(6, count($indexResults));
+        self::assertCount(6, $indexResults);
 
         /** @var Index $indexResult */
         foreach ($indexResults as $indexResult) {
@@ -52,7 +51,7 @@ class IndexListenerTest extends AbstractIndexTest
         }
     }
 
-    public function testEntityUpdate()
+    public function testEntityUpdate(): void
     {
         /** @var EntityManagerInterface $em */
         $em = self::getContainer()->get(EntityManagerInterface::class);
@@ -103,26 +102,23 @@ class IndexListenerTest extends AbstractIndexTest
         }
     }
 
-    public function testEntityDelete()
+    public function testEntityDelete(): void
     {
         /** @var EntityManagerInterface $em */
         $em = self::getContainer()->get(EntityManagerInterface::class);
 
         /** @var Contact $contact */
-        $contact = ContactFactory::createOne()->object();
+        $contact = ContactFactory::createOne([
+            'company' => CompanyFactory::createOne([
+                'name' => 'company',
+                'city' => 'city',
+                'country' => 'country',
+                'taxIdentificationNumber' => '123456',
+            ]),
+        ])->object();
 
         $contactId = $contact->getId();
 
-        $em->clear();
-
-        $contact = $em->getRepository(Contact::class)->find($contactId);
-
-        $contact->getCompany()->setName('company');
-        $contact->getCompany()->setCity('city');
-        $contact->getCompany()->setCountry('county');
-        $contact->getCompany()->setTaxIdentificationNumber('123456');
-
-        $em->flush();
         $em->clear();
 
         $indexResults = $em->getRepository(Index::class)->findAll();

--- a/tests/OneFieldPopulateTest.php
+++ b/tests/OneFieldPopulateTest.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class OneFieldPopulateTest extends AbstractIndexTest
 {
-    public function testPopulate()
+    public function testPopulate(): void
     {
         /** @var OneFieldPopulator $populator */
         $populator = self::getContainer()->get(PopulatorInterface::class);
@@ -24,7 +24,7 @@ class OneFieldPopulateTest extends AbstractIndexTest
             ->getRepository(Index::class)->count([]));
     }
 
-    public function testListnerPopulate()
+    public function testListnerPopulate(): void
     {
         $this->createEntities();
 
@@ -32,7 +32,7 @@ class OneFieldPopulateTest extends AbstractIndexTest
             ->getRepository(Index::class)->count([]));
     }
 
-    public function testDisableListnerPopulate()
+    public function testDisableListnerPopulate(): void
     {
         /** @var OneFieldPopulator $populator */
         $populator = self::getContainer()->get(PopulatorInterface::class);

--- a/tests/PopulateCommandTest.php
+++ b/tests/PopulateCommandTest.php
@@ -12,7 +12,7 @@ class PopulateCommandTest extends AbstractIndexTest
 {
     use InteractsWithConsole;
 
-    public function testPopulateCommand()
+    public function testPopulateCommand(): void
     {
         $this->createEntities();
 

--- a/tests/PopulateTest.php
+++ b/tests/PopulateTest.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class PopulateTest extends AbstractIndexTest
 {
-    public function testPopulate()
+    public function testPopulate(): void
     {
         $populator = self::getContainer()->get(PopulatorInterface::class);
         $populator->resetVisited();
@@ -28,7 +28,7 @@ class PopulateTest extends AbstractIndexTest
             ->getRepository(Index::class)->count([]));
     }
 
-    public function testPopulateCompanies()
+    public function testPopulateCompanies(): void
     {
         $this->createEntities();
 
@@ -41,7 +41,7 @@ class PopulateTest extends AbstractIndexTest
             ->getRepository(Index::class)->count([]));
     }
 
-    public function testPopulateNotEntity()
+    public function testPopulateNotEntity(): void
     {
         /** @var PopulatorInterface $populator */
         $populator = self::getContainer()->get(PopulatorInterface::class);
@@ -51,7 +51,7 @@ class PopulateTest extends AbstractIndexTest
         $populator->populate(null, NotADoctrinieModel::class);
     }
 
-    public function testPopulateNotIndexEntity()
+    public function testPopulateNotIndexEntity(): void
     {
         /** @var PopulatorInterface $populator */
         $populator = self::getContainer()->get(PopulatorInterface::class);
@@ -61,7 +61,7 @@ class PopulateTest extends AbstractIndexTest
         $populator->populate(null, Person::class);
     }
 
-    public function testDisablePopulate()
+    public function testDisablePopulate(): void
     {
         /** @var PopulatorInterface $populator */
         $populator = self::getContainer()->get(PopulatorInterface::class);

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -10,7 +10,7 @@ use araise\SearchBundle\Tests\App\Entity\Company;
 
 class SearchTest extends AbstractSearchTest
 {
-    public function testSearchAll()
+    public function testSearchAll(): void
     {
         $this->createEntities();
 
@@ -19,7 +19,7 @@ class SearchTest extends AbstractSearchTest
         self::assertCount(6, $result);
     }
 
-    public function testSearchEntity()
+    public function testSearchEntity(): void
     {
         $this->createEntities();
 
@@ -28,7 +28,7 @@ class SearchTest extends AbstractSearchTest
         self::assertCount(1, $result);
     }
 
-    public function testSearchGroup()
+    public function testSearchGroup(): void
     {
         $this->createEntities();
 

--- a/tests/TokenizerTest.php
+++ b/tests/TokenizerTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class TokenizerTest extends TestCase
 {
-    public function testLowerCaseFilter()
+    public function testLowerCaseFilter(): void
     {
         $tokeizer = new StandardTokenizer();
 

--- a/tests/WiringTest.php
+++ b/tests/WiringTest.php
@@ -11,7 +11,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class WiringTest extends KernelTestCase
 {
-    public function testServiceWiring()
+    public function testServiceWiring(): void
     {
         foreach ([
             IndexManager::class,


### PR DESCRIPTION
If those were fixed, we could raise the phpstan level to 5 with this PR:
```
 ------ -------------------------------------------------------------------------------------------------------------- 
  Line   src/Populator/OneFieldPopulator.php                                                                           
 ------ -------------------------------------------------------------------------------------------------------------- 
  54     Call to an undefined method Doctrine\ORM\EntityRepository<araise\SearchBundle\Entity\Index>::findExisting().  
 ------ -------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------- 
  Line   src/Populator/StandardPopulator.php                                                                           
 ------ -------------------------------------------------------------------------------------------------------------- 
  58     Call to an undefined method Doctrine\ORM\EntityRepository<araise\SearchBundle\Entity\Index>::findExisting().  
 ------ --------------------------------------------------------------------------------------------------------------
```

But I need someone else to take a look at this. I don't really get where the problem is.
We should also test this cleanup in a project to see if it holds up. 
The Unit Tests pass, but if that is enough - I'm not sure... 🤔 